### PR TITLE
feat: payment status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
 
       - name: Install dependencies

--- a/agent/src/app.ts
+++ b/agent/src/app.ts
@@ -1,39 +1,36 @@
 import cors from 'cors'
-import { createHash } from 'crypto'
 import express from 'express'
-import { popPendingCredentialResponseMetadata } from './utils/credentialResponseMetadata.js'
+import { credentialResponseMetadata } from './utils/credentialResponseMetadata.js'
 
 export const app = express()
 app.use(cors({ origin: '*' }))
 app.use(express.json())
 app.use(express.urlencoded())
 
-// Intercept credential endpoint responses to inject credential_metadata.
-// The credential mapper sets pending metadata keyed by sha256(access_token).
-// This middleware must be registered before agent.initialize() mounts the OID4VCI routes.
+// Intercept credential endpoint responses to inject credential_metadata set by
+// the credential mapper. Must be registered before agent.initialize() mounts
+// the OID4VCI routes.
 app.use('/oid4vci', (req, res, next) => {
   if (!req.path.endsWith('/credential')) return next()
 
-  const token = req.headers.authorization?.startsWith('Bearer ') ? req.headers.authorization.slice(7) : undefined
-
-  if (!token) return next()
-
-  const originalSend = res.send.bind(res)
-  res.send = (body: unknown) => {
-    if (typeof body === 'string') {
-      try {
-        const parsed = JSON.parse(body) as Record<string, unknown>
-        const hash = createHash('sha256').update(token).digest('hex')
-        const credentialMetadata = popPendingCredentialResponseMetadata(hash)
-        if (credentialMetadata) {
-          body = JSON.stringify({ ...parsed, credential_metadata: credentialMetadata })
+  credentialResponseMetadata.run(() => {
+    const originalSend = res.send.bind(res)
+    res.send = (body: unknown) => {
+      const metadata = credentialResponseMetadata.get()
+      if (typeof body === 'string' && metadata) {
+        try {
+          const parsed = JSON.parse(body) as Record<string, unknown>
+          const existing =
+            typeof parsed.credential_metadata === 'object' && parsed.credential_metadata !== null
+              ? (parsed.credential_metadata as Record<string, unknown>)
+              : {}
+          body = JSON.stringify({ ...parsed, credential_metadata: { ...existing, ...metadata } })
+        } catch {
+          // not JSON, leave body unchanged
         }
-      } catch {
-        // not JSON, leave body unchanged
       }
+      return originalSend(body)
     }
-    return originalSend(body)
-  }
-
-  next()
+    next()
+  })
 })

--- a/agent/src/app.ts
+++ b/agent/src/app.ts
@@ -1,7 +1,39 @@
 import cors from 'cors'
+import { createHash } from 'crypto'
 import express from 'express'
+import { popPendingCredentialResponseMetadata } from './utils/credentialResponseMetadata.js'
 
 export const app = express()
 app.use(cors({ origin: '*' }))
 app.use(express.json())
 app.use(express.urlencoded())
+
+// Intercept credential endpoint responses to inject credential_metadata.
+// The credential mapper sets pending metadata keyed by sha256(access_token).
+// This middleware must be registered before agent.initialize() mounts the OID4VCI routes.
+app.use('/oid4vci', (req, res, next) => {
+  if (!req.path.endsWith('/credential')) return next()
+
+  const token = req.headers.authorization?.startsWith('Bearer ') ? req.headers.authorization.slice(7) : undefined
+
+  if (!token) return next()
+
+  const originalSend = res.send.bind(res)
+  res.send = (body: unknown) => {
+    if (typeof body === 'string') {
+      try {
+        const parsed = JSON.parse(body) as Record<string, unknown>
+        const hash = createHash('sha256').update(token).digest('hex')
+        const credentialMetadata = popPendingCredentialResponseMetadata(hash)
+        if (credentialMetadata) {
+          body = JSON.stringify({ ...parsed, credential_metadata: credentialMetadata })
+        }
+      } catch {
+        // not JSON, leave body unchanged
+      }
+    }
+    return originalSend(body)
+  }
+
+  next()
+})

--- a/agent/src/endpoints.ts
+++ b/agent/src/endpoints.ts
@@ -13,7 +13,7 @@ import {
   X509ModuleConfig,
 } from '@credo-ts/core'
 import { type OpenId4VcVerificationSessionRecord, OpenId4VcVerificationSessionState } from '@credo-ts/openid4vc'
-import { randomUUID } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
 import express, { type NextFunction, type Request, type Response } from 'express'
 import z from 'zod'
 import { agent } from './agent.js'
@@ -179,14 +179,17 @@ apiRouter.get('/verifier', async (_, response: Response) => {
   })
 })
 
-apiRouter.post('transaction-status', async (request: Request, response: Response) => {
+apiRouter.post('/transaction-status', async (request: Request, response: Response) => {
   const authHeader = request.headers.authorization
   const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined
+  if (!token) {
+    return response.status(401)
+  }
 
   const parseResult = await z.object({ transaction: z.string() }).safeParseAsync(request.body)
   if (!parseResult.success) {
     agent.config.logger.warn('transaction-status: missing transactionId in request body')
-    return response.status(400).json({ error: 'Missing transactionId' })
+    return response.status(401)
   }
 
   const { transaction } = parseResult.data
@@ -303,7 +306,28 @@ apiRouter.post('/requests/create', async (request: Request, response: Response) 
 
     const responseCode = randomUUID()
     const redirectUri = redirectUriBase ? `${redirectUriBase}?response_code=${responseCode}` : undefined
-    const paymentTransactionId = transactionAuthorizationType === 'payment' ? randomUUID() : undefined
+    const paymentTransactionEntry =
+      transactionAuthorizationType === 'payment'
+        ? {
+            type: 'urn:eudi:sca:eu.europa.ec:payment:single:1',
+            credential_ids: [credentialIds[credentialIds.length - 1]] as [string, ...string[]],
+            transaction_data_hashes_alg: ['sha-256'] as [string, ...string[]],
+            payload: {
+              transaction_id: randomUUID(),
+              amount: `${paymentAmount} EUR`,
+              date_time: new Date().toISOString(),
+              payee: {
+                name: verifier.clientMetadata?.client_name ?? 'TODO: NAME',
+                id: verifierId,
+                logo: verifier.clientMetadata?.logo_uri ?? 'TODO: logo',
+                website: 'https://playground.animo.id',
+              },
+            },
+          }
+        : undefined
+    const paymentTransactionId = paymentTransactionEntry
+      ? createHash('sha256').update(JsonEncoder.toBase64Url(paymentTransactionEntry)).digest('hex')
+      : undefined
 
     // When credential_sets is used we need to add the wero card to each group so that it will always be requested when also requesting a payment
     if (transactionAuthorizationType === 'payment') {
@@ -357,26 +381,8 @@ apiRouter.post('/requests/create', async (request: Request, response: Response) 
                   ],
                 },
               ]
-            : transactionAuthorizationType === 'payment'
-              ? [
-                  {
-                    type: 'urn:eudi:sca:eu.europa.ec:payment:single:1',
-                    // We pick the last credential id as we push the wero card
-                    credential_ids: [credentialIds[credentialIds.length - 1]] as [string, ...string[]],
-                    transaction_data_hashes_alg: ['sha-256'],
-                    payload: {
-                      transaction_id: paymentTransactionId as string,
-                      amount: `${paymentAmount} EUR`,
-                      date_time: new Date().toISOString(),
-                      payee: {
-                        name: verifier.clientMetadata?.client_name ?? 'TODO: NAME',
-                        id: verifierId,
-                        logo: verifier.clientMetadata?.logo_uri ?? 'TODO: logo',
-                        website: 'https://playground.animo.id',
-                      },
-                    },
-                  },
-                ]
+            : transactionAuthorizationType === 'payment' && paymentTransactionEntry
+              ? [paymentTransactionEntry]
               : undefined,
         dcql: {
           query: queryLanguageDefinition,
@@ -473,16 +479,14 @@ async function getVerificationStatus(verificationSession: OpenId4VcVerificationS
     })
     if (rawPaymentEntry && weroJti) {
       const decoded = JSON.parse(Buffer.from(rawPaymentEntry, 'base64url').toString()) as {
-        payload?: { amount?: string; transaction_id?: string }
+        payload?: { amount?: string }
       }
-      const paymentTransactionId = decoded.payload?.transaction_id
+      const paymentTransactionId = createHash('sha256').update(rawPaymentEntry).digest('hex')
       const amount = parseFloat(decoded.payload?.amount ?? '0')
       agent.config.logger.info(
         `getVerificationStatus: Wero credential jti ${weroJti}, paymentTransactionId ${paymentTransactionId}, amount ${amount}`
       )
-      if (paymentTransactionId) {
-        await updatePaymentStatusForWeroCredential(weroJti, paymentTransactionId, amount)
-      }
+      await updatePaymentStatusForWeroCredential(weroJti, paymentTransactionId, amount)
     } else {
       agent.config.logger.debug(
         `getVerificationStatus: no payment update - weroJti ${weroJti ?? 'not found'}, rawPaymentEntry ${rawPaymentEntry ? 'found' : 'not found'}`

--- a/agent/src/endpoints.ts
+++ b/agent/src/endpoints.ts
@@ -20,6 +20,11 @@ import { agent } from './agent.js'
 import { funkeDeployedAccessCertificate, funkeDeployedRegistrationCertificate } from './eudiTrust.js'
 import { getIssuerIdForCredentialConfigurationId, type IssuanceMetadata } from './issuer.js'
 import { issuers } from './issuers/index.js'
+import {
+  updatePaymentStatusForWeroCredential,
+  weroScaConfiguration,
+  weroScaThirdPartyConfiguration,
+} from './issuers/openHorizonBank.js'
 import { getX509DcsCertificate, getX509RootCertificate } from './keyMethods/index.js'
 import { oidcUrl } from './oidcProvider/provider.js'
 import { LimitedSizeCollection } from './utils/LimitedSizeCollection.js'
@@ -174,6 +179,35 @@ apiRouter.get('/verifier', async (_, response: Response) => {
   })
 })
 
+apiRouter.post('transaction-status', async (request: Request, response: Response) => {
+  const authHeader = request.headers.authorization
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined
+
+  const parseResult = await z.object({ transaction: z.string() }).safeParseAsync(request.body)
+  if (!parseResult.success) {
+    agent.config.logger.warn('transaction-status: missing transactionId in request body')
+    return response.status(400).json({ error: 'Missing transactionId' })
+  }
+
+  const { transaction } = parseResult.data
+  agent.config.logger.info(`transaction-status: looking up record for transaction ${transaction}`)
+  const record = await agent.genericRecords.findById(`transaction-status-${transaction}`)
+
+  if (!record || record.content.transaction_status_token !== token || !('statusCode' in record.content)) {
+    agent.config.logger.warn(
+      `transaction-status: unauthorized - record ${record ? 'found but token mismatch or no statusCode' : 'not found'}`
+    )
+    return response.status(401)
+  }
+
+  agent.config.logger.info(
+    `transaction-status: returning status ${record.content.statusCode} for transaction ${transaction}`
+  )
+  return response.json({
+    status_code: record.content.statusCode,
+  })
+})
+
 // apiRouter.post('/trust-chains', async (request: Request, response: Response) => {
 //   const parseResult = await z
 //     .object({
@@ -262,13 +296,14 @@ apiRouter.post('/requests/create', async (request: Request, response: Response) 
       }
     }
 
-    console.log('Requesting definition', JSON.stringify(definition, null, 2))
+    agent.config.logger.debug(`Requesting definition ${JSON.stringify(definition, null, 2)}`)
 
     const queryLanguageDefinition = dcqlQueryFromRequest(definition, purpose)
     const credentialIds = queryLanguageDefinition.credentials.map((query) => query.id)
 
     const responseCode = randomUUID()
     const redirectUri = redirectUriBase ? `${redirectUriBase}?response_code=${responseCode}` : undefined
+    const paymentTransactionId = transactionAuthorizationType === 'payment' ? randomUUID() : undefined
 
     // When credential_sets is used we need to add the wero card to each group so that it will always be requested when also requesting a payment
     if (transactionAuthorizationType === 'payment') {
@@ -330,7 +365,7 @@ apiRouter.post('/requests/create', async (request: Request, response: Response) 
                     credential_ids: [credentialIds[credentialIds.length - 1]] as [string, ...string[]],
                     transaction_data_hashes_alg: ['sha-256'],
                     payload: {
-                      transaction_id: randomUUID(),
+                      transaction_id: paymentTransactionId as string,
                       amount: `${paymentAmount} EUR`,
                       date_time: new Date().toISOString(),
                       payee: {
@@ -358,24 +393,29 @@ apiRouter.post('/requests/create', async (request: Request, response: Response) 
       responseCodeMap.set(responseCode, verificationSession.id)
     }
 
+    if (transactionAuthorizationType === 'payment' && paymentTransactionId) {
+      agent.config.logger.info(
+        `requests/create: saving PDNG payment record for paymentTransactionId ${paymentTransactionId}`
+      )
+      await agent.genericRecords.save({
+        id: `transaction-status-${paymentTransactionId}`,
+        content: { statusCode: 'PDNG' },
+      })
+    }
+
     const authorizationRequestJwt = verificationSession.authorizationRequestJwt
       ? Jwt.fromSerializedJwt(verificationSession.authorizationRequestJwt)
       : undefined
     const authorizationRequestPayload = verificationSession.requestPayload
     const dcqlQuery = authorizationRequestPayload.dcql_query
-    const transactionData = authorizationRequestPayload.verifier_info?.map((e) => ({
-      ...e,
-      data: typeof e.data === 'string' ? JsonEncoder.fromBase64(e.data) : e.data,
-    }))
 
-    console.log(JSON.stringify(authorizationRequestObject, null, 2))
+    agent.config.logger.debug(JSON.stringify(authorizationRequestObject, null, 2))
     return response.json({
       authorizationRequestObject,
       authorizationRequestUri: authorizationRequest.replace('openid4vp://', requestScheme),
       verificationSessionId: verificationSession.id,
       responseStatus: verificationSession.state,
       dcqlQuery,
-      transactionData,
       authorizationRequest: authorizationRequestJwt
         ? {
             payload: authorizationRequestJwt.payload.toJson(),
@@ -409,7 +449,45 @@ async function getVerificationStatus(verificationSession: OpenId4VcVerificationS
 
   if (verificationSession.state === OpenId4VcVerificationSessionState.ResponseVerified) {
     const verified = await agent.openid4vc.verifier.getVerifiedAuthorizationResponse(verificationSession.id)
-    console.log(verified.dcql?.presentationResult)
+    agent.config.logger.debug(JSON.stringify(verified.dcql?.presentationResult))
+
+    // Find the Wero SCA presentation to extract the credential jti, then signal the issuer to update payment status.
+    // The issuer owns the transaction_status_token — the verifier only passes the jti and payment details.
+    const weroVcts = [weroScaConfiguration.vct, weroScaThirdPartyConfiguration.vct]
+    const weroPresentation = Object.values(verified.dcql?.presentations ?? {})
+      .flat()
+      .find((p) => weroVcts.includes((p as { prettyClaims?: Record<string, unknown> }).prettyClaims?.vct as string))
+    const weroJti = (weroPresentation as { prettyClaims?: Record<string, unknown> } | undefined)?.prettyClaims?.jti as
+      | string
+      | undefined
+
+    const rawPaymentEntry = (authorizationRequestPayload.transaction_data as string[] | undefined)?.find((data) => {
+      try {
+        return (
+          (JSON.parse(Buffer.from(data, 'base64url').toString()) as { type?: string }).type ===
+          'urn:eudi:sca:eu.europa.ec:payment:single:1'
+        )
+      } catch {
+        return false
+      }
+    })
+    if (rawPaymentEntry && weroJti) {
+      const decoded = JSON.parse(Buffer.from(rawPaymentEntry, 'base64url').toString()) as {
+        payload?: { amount?: string; transaction_id?: string }
+      }
+      const paymentTransactionId = decoded.payload?.transaction_id
+      const amount = parseFloat(decoded.payload?.amount ?? '0')
+      agent.config.logger.info(
+        `getVerificationStatus: Wero credential jti ${weroJti}, paymentTransactionId ${paymentTransactionId}, amount ${amount}`
+      )
+      if (paymentTransactionId) {
+        await updatePaymentStatusForWeroCredential(weroJti, paymentTransactionId, amount)
+      }
+    } else {
+      agent.config.logger.debug(
+        `getVerificationStatus: no payment update - weroJti ${weroJti ?? 'not found'}, rawPaymentEntry ${rawPaymentEntry ? 'found' : 'not found'}`
+      )
+    }
 
     const presentations = await Promise.all(
       Object.values(verified.dcql?.presentations ?? {})
@@ -497,7 +575,7 @@ async function getVerificationStatus(verificationSession: OpenId4VcVerificationS
         }))
       : undefined
 
-    console.log('presentations', presentations)
+    agent.config.logger.debug(`presentations ${JSON.stringify(presentations)}`)
 
     return {
       verificationSessionId: verificationSession.id,
@@ -559,7 +637,7 @@ apiRouter.get('/requests/:verificationSessionId', async (request, response) => {
 })
 
 apiRouter.use((error: Error, _request: Request, response: Response, _next: NextFunction) => {
-  console.error('Unhandled error', error)
+  agent.config.logger.error(`Unhandled error ${error}`)
   return response.status(500).json({
     error: error.message,
   })

--- a/agent/src/endpoints.ts
+++ b/agent/src/endpoints.ts
@@ -485,7 +485,7 @@ async function getVerificationStatus(verificationSession: OpenId4VcVerificationS
       agent.config.logger.info(
         `getVerificationStatus: Wero credential jti ${weroJti}, paymentTransactionId ${paymentTransactionId}, amount ${amount}`
       )
-      updatePaymentStatusForWeroCredential(weroJti, paymentTransactionId, amount).catch((error) => {
+      await updatePaymentStatusForWeroCredential(weroJti, paymentTransactionId, amount).catch((error) => {
         agent.config.logger.error(`getVerificationStatus: payment update failed for ${paymentTransactionId}`, error)
       })
     } else {

--- a/agent/src/endpoints.ts
+++ b/agent/src/endpoints.ts
@@ -1,5 +1,5 @@
 import {
-  JsonEncoder,
+  Hasher,
   JsonTransformer,
   Jwt,
   MdocDeviceResponse,
@@ -13,7 +13,7 @@ import {
   X509ModuleConfig,
 } from '@credo-ts/core'
 import { type OpenId4VcVerificationSessionRecord, OpenId4VcVerificationSessionState } from '@credo-ts/openid4vc'
-import { createHash, randomUUID } from 'crypto'
+import { randomUUID } from 'crypto'
 import express, { type NextFunction, type Request, type Response } from 'express'
 import z from 'zod'
 import { agent } from './agent.js'
@@ -57,6 +57,28 @@ const deferIntervalMapping: Record<z.infer<typeof zCreateOfferRequest>['deferBy'
 
 apiRouter.use(express.json())
 apiRouter.use(express.text())
+
+// Extracts paymentTransactionId (hash of the raw transaction_data entry, matching
+// what the wallet computes per the transaction_data spec) and the amount from the
+// authorization request JWT. Returns undefined if no transaction_data is present.
+function extractPaymentTransactionData(
+  authorizationRequestJwt: string | undefined
+): { paymentTransactionId: string; amount: number } | undefined {
+  if (!authorizationRequestJwt) return undefined
+
+  const transactionData = Jwt.fromSerializedJwt(authorizationRequestJwt).payload.additionalClaims.transaction_data
+  if (!Array.isArray(transactionData) || typeof transactionData[0] !== 'string') return undefined
+
+  const rawEntry = transactionData[0]
+  const paymentTransactionId = TypedArrayEncoder.toHex(
+    Hasher.hash(TypedArrayEncoder.fromBase64Url(rawEntry), 'sha-256')
+  )
+  const decoded = JSON.parse(Buffer.from(rawEntry, 'base64url').toString()) as { payload?: { amount?: string } }
+  const amount = parseFloat(decoded.payload?.amount ?? '0')
+
+  return { paymentTransactionId, amount }
+}
+
 apiRouter.post('/offers/create', async (request: Request, response: Response) => {
   const createOfferRequest = zCreateOfferRequest.parse(request.body)
 
@@ -183,13 +205,13 @@ apiRouter.post('/transaction-status', async (request: Request, response: Respons
   const authHeader = request.headers.authorization
   const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined
   if (!token) {
-    return response.status(401)
+    return response.sendStatus(401)
   }
 
   const parseResult = await z.object({ transaction: z.string() }).safeParseAsync(request.body)
   if (!parseResult.success) {
     agent.config.logger.warn('transaction-status: missing transactionId in request body')
-    return response.status(401)
+    return response.sendStatus(401)
   }
 
   const { transaction } = parseResult.data
@@ -200,7 +222,7 @@ apiRouter.post('/transaction-status', async (request: Request, response: Respons
     agent.config.logger.warn(
       `transaction-status: unauthorized - record ${record ? 'found but token mismatch or no statusCode' : 'not found'}`
     )
-    return response.status(401)
+    return response.sendStatus(401)
   }
 
   agent.config.logger.info(
@@ -265,7 +287,6 @@ apiRouter.post('/requests/create', async (request: Request, response: Response) 
       redirectUriBase,
     } = await zCreatePresentationRequestBody.parseAsync(request.body)
 
-    const _x509RootCertificate = getX509RootCertificate()
     const x509DcsCertificate = getX509DcsCertificate()
 
     // Funke access certificate uses same key as the dcs certificate
@@ -325,9 +346,6 @@ apiRouter.post('/requests/create', async (request: Request, response: Response) 
             },
           }
         : undefined
-    const paymentTransactionId = paymentTransactionEntry
-      ? createHash('sha256').update(JsonEncoder.toBase64Url(paymentTransactionEntry)).digest('hex')
-      : undefined
 
     // When credential_sets is used we need to add the wero card to each group so that it will always be requested when also requesting a payment
     if (transactionAuthorizationType === 'payment') {
@@ -399,12 +417,13 @@ apiRouter.post('/requests/create', async (request: Request, response: Response) 
       responseCodeMap.set(responseCode, verificationSession.id)
     }
 
-    if (transactionAuthorizationType === 'payment' && paymentTransactionId) {
+    const paymentTransaction = extractPaymentTransactionData(verificationSession.authorizationRequestJwt)
+    if (transactionAuthorizationType === 'payment' && paymentTransaction) {
       agent.config.logger.info(
-        `requests/create: saving PDNG payment record for paymentTransactionId ${paymentTransactionId}`
+        `requests/create: saving PDNG payment record for paymentTransactionId ${paymentTransaction.paymentTransactionId}`
       )
       await agent.genericRecords.save({
-        id: `transaction-status-${paymentTransactionId}`,
+        id: `transaction-status-${paymentTransaction.paymentTransactionId}`,
         content: { statusCode: 'PDNG' },
       })
     }
@@ -448,48 +467,30 @@ async function getVerificationStatus(verificationSession: OpenId4VcVerificationS
   }
   const dcqlQuery = authorizationRequestPayload.dcql_query
 
-  const transactionData = authorizationRequestPayload.verifier_info?.map((e) => ({
-    ...e,
-    data: typeof e.data === 'string' ? JsonEncoder.fromBase64(e.data) : e.data,
-  }))
-
   if (verificationSession.state === OpenId4VcVerificationSessionState.ResponseVerified) {
     const verified = await agent.openid4vc.verifier.getVerifiedAuthorizationResponse(verificationSession.id)
     agent.config.logger.debug(JSON.stringify(verified.dcql?.presentationResult))
 
     // Find the Wero SCA presentation to extract the credential jti, then signal the issuer to update payment status.
     // The issuer owns the transaction_status_token — the verifier only passes the jti and payment details.
-    const weroVcts = [weroScaConfiguration.vct, weroScaThirdPartyConfiguration.vct]
-    const weroPresentation = Object.values(verified.dcql?.presentations ?? {})
-      .flat()
-      .find((p) => weroVcts.includes((p as { prettyClaims?: Record<string, unknown> }).prettyClaims?.vct as string))
-    const weroJti = (weroPresentation as { prettyClaims?: Record<string, unknown> } | undefined)?.prettyClaims?.jti as
-      | string
-      | undefined
+    const weroVcts: string[] = [weroScaConfiguration.vct, weroScaThirdPartyConfiguration.vct]
+    const presentationsList = Object.values(verified.dcql?.presentations ?? {}).flat() as Array<{
+      prettyClaims?: { vct?: string; jti?: string }
+    }>
+    const weroJti = presentationsList.find((p) => weroVcts.includes(p.prettyClaims?.vct ?? ''))?.prettyClaims?.jti
 
-    const rawPaymentEntry = (authorizationRequestPayload.transaction_data as string[] | undefined)?.find((data) => {
-      try {
-        return (
-          (JSON.parse(Buffer.from(data, 'base64url').toString()) as { type?: string }).type ===
-          'urn:eudi:sca:eu.europa.ec:payment:single:1'
-        )
-      } catch {
-        return false
-      }
-    })
-    if (rawPaymentEntry && weroJti) {
-      const decoded = JSON.parse(Buffer.from(rawPaymentEntry, 'base64url').toString()) as {
-        payload?: { amount?: string }
-      }
-      const paymentTransactionId = createHash('sha256').update(rawPaymentEntry).digest('hex')
-      const amount = parseFloat(decoded.payload?.amount ?? '0')
+    const paymentTransaction = extractPaymentTransactionData(verificationSession.authorizationRequestJwt)
+    if (weroJti && paymentTransaction) {
+      const { paymentTransactionId, amount } = paymentTransaction
       agent.config.logger.info(
         `getVerificationStatus: Wero credential jti ${weroJti}, paymentTransactionId ${paymentTransactionId}, amount ${amount}`
       )
-      await updatePaymentStatusForWeroCredential(weroJti, paymentTransactionId, amount)
+      updatePaymentStatusForWeroCredential(weroJti, paymentTransactionId, amount).catch((error) => {
+        agent.config.logger.error(`getVerificationStatus: payment update failed for ${paymentTransactionId}`, error)
+      })
     } else {
       agent.config.logger.debug(
-        `getVerificationStatus: no payment update - weroJti ${weroJti ?? 'not found'}, rawPaymentEntry ${rawPaymentEntry ? 'found' : 'not found'}`
+        `getVerificationStatus: no payment update - weroJti ${weroJti ?? 'not found'}, paymentTransaction ${paymentTransaction ? 'found' : 'not found'}`
       )
     }
 
@@ -602,7 +603,6 @@ async function getVerificationStatus(verificationSession: OpenId4VcVerificationS
     responseStatus: verificationSession.state,
     error: verificationSession.errorMessage,
     authorizationRequest,
-    transactionData,
     dcqlQuery,
   }
 }

--- a/agent/src/endpoints.ts
+++ b/agent/src/endpoints.ts
@@ -70,7 +70,7 @@ function extractPaymentTransactionData(
   if (!Array.isArray(transactionData) || typeof transactionData[0] !== 'string') return undefined
 
   const rawEntry = transactionData[0]
-  const paymentTransactionId = TypedArrayEncoder.toHex(
+  const paymentTransactionId = TypedArrayEncoder.toBase64Url(
     Hasher.hash(TypedArrayEncoder.fromBase64Url(rawEntry), 'sha-256')
   )
   const decoded = JSON.parse(Buffer.from(rawEntry, 'base64url').toString()) as { payload?: { amount?: string } }

--- a/agent/src/issuer.ts
+++ b/agent/src/issuer.ts
@@ -22,10 +22,12 @@ import {
 import { cborDecode, cborEncode } from '@owf/mdoc'
 import { randomUUID } from 'crypto'
 import { agent } from './agent.js'
+import { AGENT_HOST } from './constants.js'
 import { bdrIssuer } from './issuers/bdr.js'
 import { issuers, issuersCredentialsData } from './issuers/index.js'
 import { kolnIssuer } from './issuers/koln.js'
 import { krankenkasseIssuer } from './issuers/krankenkasse.js'
+import { weroScaConfiguration, weroScaThirdPartyConfiguration } from './issuers/openHorizonBank.js'
 import { steuernIssuer } from './issuers/steuern.js'
 import { telOrgIssuer } from './issuers/telOrg.js'
 import { getX509DcsCertificate } from './keyMethods/index.js'
@@ -504,9 +506,8 @@ export const credentialRequestToCredentialMapper: OpenId4VciCredentialRequestToC
           })),
         } satisfies SerializableMdocSignOptions
 
-        console.log(
-          'decoded',
-          cborDecode(Buffer.from(signOptions.credentials[0].namespaces, 'base64url'), { mapsAsObjects: true })
+        agent.config.logger.debug(
+          `decoded ${JSON.stringify(cborDecode(Buffer.from(signOptions.credentials[0].namespaces, 'base64url'), { mapsAsObjects: true }))}`
         )
       }
     }
@@ -543,6 +544,40 @@ export const credentialRequestToCredentialMapper: OpenId4VciCredentialRequestToC
     } else {
       throw new Error(`Unsupported credential ${credentialConfigurationId}`)
     }
+  }
+
+  // For Wero SCA SD-JWT credentials, inject a per-credential transaction status token
+  // We manually set the `jti` here so the issuer can refer later to update the status
+  if (
+    signOptions &&
+    credentialData.format === ClaimFormat.SdJwtDc &&
+    (normalizedCredentialConfigurationId === weroScaConfiguration.scope ||
+      normalizedCredentialConfigurationId === weroScaThirdPartyConfiguration.scope)
+  ) {
+    const jti = randomUUID() as string
+    const transaction_status_token = randomUUID() as string
+    const sdJwtSignOptions = signOptions as SerializableSdJwtVcSignOptions
+
+    signOptions = {
+      ...sdJwtSignOptions,
+      credentials: sdJwtSignOptions.credentials.map((credential) => ({
+        ...credential,
+        payload: {
+          ...credential.payload,
+          jti,
+          credential_metadata: {
+            transaction_status_url: `${AGENT_HOST}/api/transaction-status`,
+            transaction_status_token,
+          },
+        },
+      })),
+    } satisfies SerializableSdJwtVcSignOptions
+
+    await agent.genericRecords.save({
+      id: `wero-credential-token-${jti}`,
+      content: { transaction_status_token },
+    })
+    agent.config.logger.info(`issuer: saved Wero SCA transaction status record for jti ${jti}`)
   }
 
   const issuanceMetadata: IssuanceMetadata = issuanceSession.issuanceMetadata ?? {}

--- a/agent/src/issuer.ts
+++ b/agent/src/issuer.ts
@@ -20,7 +20,7 @@ import {
   OpenId4VcVerifierApi,
 } from '@credo-ts/openid4vc'
 import { cborDecode, cborEncode } from '@owf/mdoc'
-import { createHash, randomUUID } from 'crypto'
+import { randomUUID } from 'crypto'
 import { agent } from './agent.js'
 import { AGENT_HOST } from './constants.js'
 import { bdrIssuer } from './issuers/bdr.js'
@@ -32,7 +32,7 @@ import { steuernIssuer } from './issuers/steuern.js'
 import { telOrgIssuer } from './issuers/telOrg.js'
 import { getX509DcsCertificate } from './keyMethods/index.js'
 import type { StaticMdocSignInput, StaticSdJwtSignInput } from './types.js'
-import { setPendingCredentialResponseMetadata } from './utils/credentialResponseMetadata.js'
+import { credentialResponseMetadata } from './utils/credentialResponseMetadata.js'
 import { oneYearInMilliseconds, serverStartupTimeInMilliseconds, tenDaysInMilliseconds } from './utils/date.js'
 import { getVerifier } from './verifier.js'
 import { dcqlQueryFromRequest, pidMdocCredential, pidSdJwtCredential } from './verifiers/util.js'
@@ -307,7 +307,6 @@ export const credentialRequestToCredentialMapper: OpenId4VciCredentialRequestToC
   credentialConfigurationId,
   verification,
   issuanceSession,
-  authorization,
 }): Promise<OpenId4VciSignCredentials | OpenId4VciDeferredCredentials> => {
   const normalizedCredentialConfigurationId = credentialConfigurationId.replace('-key-attestations', '')
   const credentialData = issuersCredentialsData[normalizedCredentialConfigurationId]
@@ -577,8 +576,7 @@ export const credentialRequestToCredentialMapper: OpenId4VciCredentialRequestToC
     })
     agent.config.logger.info(`issuer: saved Wero SCA transaction status record for jti ${jti}`)
 
-    const accessTokenHash = createHash('sha256').update(authorization.accessToken.value).digest('hex')
-    setPendingCredentialResponseMetadata(accessTokenHash, {
+    credentialResponseMetadata.set({
       'urn:eudi:sca:eu.europa.ec:payment': {
         transaction_status_url: `${AGENT_HOST}/api/transaction-status`,
         transaction_status_token,

--- a/agent/src/issuer.ts
+++ b/agent/src/issuer.ts
@@ -20,7 +20,7 @@ import {
   OpenId4VcVerifierApi,
 } from '@credo-ts/openid4vc'
 import { cborDecode, cborEncode } from '@owf/mdoc'
-import { randomUUID } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
 import { agent } from './agent.js'
 import { AGENT_HOST } from './constants.js'
 import { bdrIssuer } from './issuers/bdr.js'
@@ -32,6 +32,7 @@ import { steuernIssuer } from './issuers/steuern.js'
 import { telOrgIssuer } from './issuers/telOrg.js'
 import { getX509DcsCertificate } from './keyMethods/index.js'
 import type { StaticMdocSignInput, StaticSdJwtSignInput } from './types.js'
+import { setPendingCredentialResponseMetadata } from './utils/credentialResponseMetadata.js'
 import { oneYearInMilliseconds, serverStartupTimeInMilliseconds, tenDaysInMilliseconds } from './utils/date.js'
 import { getVerifier } from './verifier.js'
 import { dcqlQueryFromRequest, pidMdocCredential, pidSdJwtCredential } from './verifiers/util.js'
@@ -306,6 +307,7 @@ export const credentialRequestToCredentialMapper: OpenId4VciCredentialRequestToC
   credentialConfigurationId,
   verification,
   issuanceSession,
+  authorization,
 }): Promise<OpenId4VciSignCredentials | OpenId4VciDeferredCredentials> => {
   const normalizedCredentialConfigurationId = credentialConfigurationId.replace('-key-attestations', '')
   const credentialData = issuersCredentialsData[normalizedCredentialConfigurationId]
@@ -546,8 +548,8 @@ export const credentialRequestToCredentialMapper: OpenId4VciCredentialRequestToC
     }
   }
 
-  // For Wero SCA SD-JWT credentials, inject a per-credential transaction status token
-  // We manually set the `jti` here so the issuer can refer later to update the status
+  // For Wero SCA SD-JWT credentials, inject a per-credential jti and schedule
+  // credential_metadata to be added to the OID4VCI credential response (not the credential itself).
   if (
     signOptions &&
     credentialData.format === ClaimFormat.SdJwtDc &&
@@ -565,10 +567,6 @@ export const credentialRequestToCredentialMapper: OpenId4VciCredentialRequestToC
         payload: {
           ...credential.payload,
           jti,
-          credential_metadata: {
-            transaction_status_url: `${AGENT_HOST}/api/transaction-status`,
-            transaction_status_token,
-          },
         },
       })),
     } satisfies SerializableSdJwtVcSignOptions
@@ -578,6 +576,14 @@ export const credentialRequestToCredentialMapper: OpenId4VciCredentialRequestToC
       content: { transaction_status_token },
     })
     agent.config.logger.info(`issuer: saved Wero SCA transaction status record for jti ${jti}`)
+
+    const accessTokenHash = createHash('sha256').update(authorization.accessToken.value).digest('hex')
+    setPendingCredentialResponseMetadata(accessTokenHash, {
+      'urn:eudi:sca:eu.europa.ec:payment': {
+        transaction_status_url: `${AGENT_HOST}/api/transaction-status`,
+        transaction_status_token,
+      },
+    })
   }
 
   const issuanceMetadata: IssuanceMetadata = issuanceSession.issuanceMetadata ?? {}

--- a/agent/src/issuers/openHorizonBank.ts
+++ b/agent/src/issuers/openHorizonBank.ts
@@ -205,9 +205,6 @@ export async function updatePaymentStatusForWeroCredential(
   amount: number
 ): Promise<void> {
   const statusCode = amount > 100 ? 'RJCT' : 'ACSC'
-  agent.config.logger.info(
-    `openHorizonBank: updating payment ${paymentTransactionId} for credential ${jti}, amount ${amount} -> ${statusCode}`
-  )
 
   const credentialTokenRecord = await agent.genericRecords.findById(`wero-credential-token-${jti}`)
   if (!credentialTokenRecord) {
@@ -224,9 +221,23 @@ export async function updatePaymentStatusForWeroCredential(
   }
 
   paymentRecord.content.transaction_status_token = credentialTokenRecord.content.transaction_status_token
-  paymentRecord.content.statusCode = statusCode
   await agent.genericRecords.update(paymentRecord)
-  agent.config.logger.info(`openHorizonBank: payment ${paymentTransactionId} updated to ${statusCode}`)
+  agent.config.logger.info(
+    `openHorizonBank: payment ${paymentTransactionId} token set (status PDNG), flipping to ${statusCode} in 30s`
+  )
+
+  setTimeout(async () => {
+    const latest = await agent.genericRecords.findById(`transaction-status-${paymentTransactionId}`)
+    if (!latest || latest.content.statusCode !== 'PDNG') {
+      agent.config.logger.warn(
+        `openHorizonBank: payment ${paymentTransactionId} no longer PDNG at flip time (current: ${latest?.content.statusCode})`
+      )
+      return
+    }
+    latest.content.statusCode = statusCode
+    await agent.genericRecords.update(latest)
+    agent.config.logger.info(`openHorizonBank: payment ${paymentTransactionId} updated to ${statusCode}`)
+  }, 30_000)
 }
 
 export const openHorizonBankCredentialsData = {

--- a/agent/src/issuers/openHorizonBank.ts
+++ b/agent/src/issuers/openHorizonBank.ts
@@ -1,5 +1,6 @@
 import { Kms } from '@credo-ts/core'
 import { OpenId4VciCredentialFormatProfile } from '@credo-ts/openid4vc'
+import { agent } from '../agent.js'
 import { AGENT_HOST } from '../constants.js'
 import type { CredentialConfigurationDisplay, PlaygroundIssuerOptions, SdJwtConfiguration } from '../issuer.js'
 import type { StaticSdJwtSignInput } from '../types.js'
@@ -196,6 +197,36 @@ export const openHorizonbankCredentialMetadata = {
       },
     },
   },
+}
+
+export async function updatePaymentStatusForWeroCredential(
+  jti: string,
+  paymentTransactionId: string,
+  amount: number
+): Promise<void> {
+  const statusCode = amount > 100 ? 'RJCT' : 'ACSC'
+  agent.config.logger.info(
+    `openHorizonBank: updating payment ${paymentTransactionId} for credential ${jti}, amount ${amount} -> ${statusCode}`
+  )
+
+  const credentialTokenRecord = await agent.genericRecords.findById(`wero-credential-token-${jti}`)
+  if (!credentialTokenRecord) {
+    agent.config.logger.warn(`openHorizonBank: no credential token record found for jti ${jti}`)
+    return
+  }
+
+  const paymentRecord = await agent.genericRecords.findById(`transaction-status-${paymentTransactionId}`)
+  if (!paymentRecord || paymentRecord.content.statusCode !== 'PDNG') {
+    agent.config.logger.warn(
+      `openHorizonBank: payment record ${paymentTransactionId} not found or not PDNG (current: ${paymentRecord?.content.statusCode})`
+    )
+    return
+  }
+
+  paymentRecord.content.transaction_status_token = credentialTokenRecord.content.transaction_status_token
+  paymentRecord.content.statusCode = statusCode
+  await agent.genericRecords.update(paymentRecord)
+  agent.config.logger.info(`openHorizonBank: payment ${paymentTransactionId} updated to ${statusCode}`)
 }
 
 export const openHorizonBankCredentialsData = {

--- a/agent/src/server.ts
+++ b/agent/src/server.ts
@@ -1,7 +1,6 @@
 import '@openwallet-foundation/askar-nodejs'
 import { JwsService, JwtPayload, Kms } from '@credo-ts/core'
 import type { Request, Response } from 'express'
-
 import express from 'express'
 import path from 'path'
 import { agent } from './agent.js'
@@ -128,7 +127,7 @@ async function run() {
 
   // Hack for making images available
   if (AGENT_HOST.includes('ngrok') || AGENT_HOST.includes('.ts.net') || AGENT_HOST.includes('localhost')) {
-    console.log(path.join(dirname, '../../app/public/assets'))
+    agent.config.logger.debug(path.join(dirname, '../../app/public/assets'))
     app.use('/assets', express.static(path.join(dirname, '../../app/public/assets')))
   }
 
@@ -192,7 +191,7 @@ async function run() {
 
   // @ts-expect-error
   app.use((err, _, res, __) => {
-    console.error(err.stack)
+    agent.config.logger.error(err.stack)
     res.status(500).send('Something broke!')
   })
 }

--- a/agent/src/utils/credentialResponseMetadata.ts
+++ b/agent/src/utils/credentialResponseMetadata.ts
@@ -1,0 +1,11 @@
+const pending = new Map<string, Record<string, unknown>>()
+
+export function setPendingCredentialResponseMetadata(accessTokenHash: string, metadata: Record<string, unknown>) {
+  pending.set(accessTokenHash, metadata)
+}
+
+export function popPendingCredentialResponseMetadata(accessTokenHash: string): Record<string, unknown> | undefined {
+  const value = pending.get(accessTokenHash)
+  pending.delete(accessTokenHash)
+  return value
+}

--- a/agent/src/utils/credentialResponseMetadata.ts
+++ b/agent/src/utils/credentialResponseMetadata.ts
@@ -1,11 +1,14 @@
-const pending = new Map<string, Record<string, unknown>>()
+import { AsyncLocalStorage } from 'node:async_hooks'
 
-export function setPendingCredentialResponseMetadata(accessTokenHash: string, metadata: Record<string, unknown>) {
-  pending.set(accessTokenHash, metadata)
-}
+type Store = { metadata?: Record<string, unknown> }
 
-export function popPendingCredentialResponseMetadata(accessTokenHash: string): Record<string, unknown> | undefined {
-  const value = pending.get(accessTokenHash)
-  pending.delete(accessTokenHash)
-  return value
+const storage = new AsyncLocalStorage<Store>()
+
+export const credentialResponseMetadata = {
+  run: (fn: () => void) => storage.run({}, fn),
+  set: (metadata: Record<string, unknown>) => {
+    const store = storage.getStore()
+    if (store) store.metadata = metadata
+  },
+  get: () => storage.getStore()?.metadata,
 }

--- a/package.json
+++ b/package.json
@@ -7,5 +7,5 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.11"
   },
-  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"
+  "packageManager": "pnpm@11.6.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,13 @@ packages:
   - agent
   - app
 
+allowBuilds:
+  '@openwallet-foundation/askar-nodejs': true
+  cbor-extract: false
+  esbuild: false
+  koffi: true
+  sharp: false
+
 ignoredBuiltDependencies:
   - es5-ext
   - esbuild


### PR DESCRIPTION
  Implements the payment transaction status polling
  flow from the EUDI Payment Status spec. After a
  Wero SCA credential is issued, the wallet can poll
  `transaction_status_url` to get the status code.
  credential_metadata injection is done via an
  Express middleware that patches res.send in
  front of the OID4VCI routes, since Credo has no
  hook for credential_metadata yet that I could find.
  Generic records are used instead of a real payment
  backend because the playground is self-contained.
  wero-credential-token-{jti} links a credential to
  its transaction_status_token without it appearing
  in the credential or presentation.
  transaction-status-{paymentTransactionId} holds the
  current status, starting at PDNG and updated after
  the SCA presentation is verified. The token is a
  random UUID rather than a signed JWT, and status
  transitions are triggered locally by the verifier
  callback rather than by an upstream payment event.